### PR TITLE
adding code to change garden photo

### DIFF
--- a/app/src/main/java/com/example/garden_planner/adapters/GardenFeedAdapter.java
+++ b/app/src/main/java/com/example/garden_planner/adapters/GardenFeedAdapter.java
@@ -1,6 +1,7 @@
 package com.example.garden_planner.adapters;
 
 import android.content.Context;
+import android.content.Intent;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.example.garden_planner.GardenMethodHelper;
 import com.example.garden_planner.MainActivity;
+import com.example.garden_planner.PictureHandlerActivity;
 import com.example.garden_planner.databinding.ItemGardenBinding;
 import com.example.garden_planner.models.Garden;
 import com.example.garden_planner.models.PlantInBed;
@@ -127,6 +129,16 @@ public class GardenFeedAdapter extends RecyclerView.Adapter<GardenFeedAdapter.Vi
             rvPlants.setLayoutManager(horizontalLayoutManager);
 
             GardenMethodHelper.queryPlantInBed(somePlants, adapter, garden);
+
+            ivGardenImage.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    MainActivity activity = (MainActivity)context;
+                    Intent i = new Intent(context, PictureHandlerActivity.class);
+                    i.putExtra("type", "garden photo");
+
+                }
+            });
         }
 
     }

--- a/app/src/main/java/com/example/garden_planner/adapters/GardenFeedAdapter.java
+++ b/app/src/main/java/com/example/garden_planner/adapters/GardenFeedAdapter.java
@@ -116,7 +116,7 @@ public class GardenFeedAdapter extends RecyclerView.Adapter<GardenFeedAdapter.Vi
             tvGardenLocation.setText("Location: "+garden.getLocation());
 
             if (garden.has("photo")){
-                Glide.with(context).load(garden.getParseFile("photo").getUrl()).into(ivGardenImage);
+                Glide.with(context).load(garden.getPhoto().getUrl()).into(ivGardenImage);
             }
 
             LinearLayoutManager horizontalLayoutManager
@@ -135,8 +135,8 @@ public class GardenFeedAdapter extends RecyclerView.Adapter<GardenFeedAdapter.Vi
                 public void onClick(View v) {
                     MainActivity activity = (MainActivity)context;
                     Intent i = new Intent(context, PictureHandlerActivity.class);
-                    i.putExtra("type", "garden photo");
-
+                    i.putExtra("garden", garden);
+                    activity.startActivity(i);
                 }
             });
         }

--- a/app/src/main/java/com/example/garden_planner/fragments/GardenDetailFragment.java
+++ b/app/src/main/java/com/example/garden_planner/fragments/GardenDetailFragment.java
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.example.garden_planner.EditGardenActivity;
 import com.example.garden_planner.GardenMethodHelper;
+import com.example.garden_planner.MainActivity;
+import com.example.garden_planner.PictureHandlerActivity;
 import com.example.garden_planner.adapters.PlantInBedAdapter;
 import com.example.garden_planner.adapters.ReminderAdapter;
 import com.example.garden_planner.databinding.FragmentGardenDetailBinding;
@@ -72,7 +74,7 @@ public class GardenDetailFragment extends Fragment {
         }
 
         if (garden.has("photo")){
-            Glide.with(getContext()).load(garden.getParseFile("photo").getUrl()).into(ivGardenImage);
+            Glide.with(getContext()).load(garden.getPhoto().getUrl()).into(ivGardenImage);
         }
 
         LinearLayoutManager horizontalLayoutManager
@@ -108,6 +110,16 @@ public class GardenDetailFragment extends Fragment {
                 getContext().startActivity(i);
             }
         });
+        ivGardenImage.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                MainActivity activity = (MainActivity)getContext();
+                Intent i = new Intent(getContext(), PictureHandlerActivity.class);
+                i.putExtra("garden", garden);
+                activity.startActivity(i);
+            }
+        });
+
     }
 
     @Override
@@ -115,6 +127,7 @@ public class GardenDetailFragment extends Fragment {
         super.onResume();
         GardenMethodHelper.queryPlantInBed(somePlants, plantInBedAdapter, garden);
         GardenMethodHelper.queryReminders(userReminders, reminderAdapter, Reminder.KEY_REMIND_WHAT, garden);
+        Glide.with(getContext()).load(garden.getPhoto().getUrl()).into(ivGardenImage);
 
     }
 }

--- a/app/src/main/java/com/example/garden_planner/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/garden_planner/fragments/ProfileFragment.java
@@ -77,7 +77,7 @@ public class ProfileFragment extends BaseFragment {
                             MainActivity activity = (MainActivity)getContext();
                             Intent i = new Intent(getContext(), PictureHandlerActivity.class);
                             activity.startActivity(i);
-                            Glide.with(getContext()).load(GardenMethodHelper.profilePic(user)).transform(new CircleCrop()).into(ivProfilePic);
+                            // Glide.with(getContext()).load(GardenMethodHelper.profilePic(user)).transform(new CircleCrop()).into(ivProfilePic);
 
                         }
                     });

--- a/app/src/main/res/layout/activity_picture_handler.xml
+++ b/app/src/main/res/layout/activity_picture_handler.xml
@@ -71,8 +71,7 @@
         android:text="Upload"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ivPhotoToUpload"
-        />
+        app:layout_constraintTop_toBottomOf="@+id/ivGardenPhoto" />
 
     <TextView
 
@@ -86,5 +85,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/btTakePhoto"
         />
+
+    <ImageView
+        android:id="@+id/ivGardenPhoto"
+        android:layout_width="match_parent"
+        android:layout_height="300dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/ivPhotoToUpload"
+        tools:srcCompat="@tools:sample/backgrounds/scenic"
+        android:padding="10dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
when garden photo is clicked, a new activity should be launched to replace the photo with a new picture - this activity is the same as the profile picture change activity, just with different text and a larger rectangular preview rather than the small circle photo preview.

<img width="227" alt="Screen Shot 2022-07-12 at 10 07 12 AM" src="https://user-images.githubusercontent.com/68405647/178551441-333a9b7a-739a-4392-9d9d-c128c1fed0e3.png">
<img width="211" alt="Screen Shot 2022-07-12 at 10 08 36 AM" src="https://user-images.githubusercontent.com/68405647/178551716-67092657-2de4-47e4-9097-e4918d0b6400.png">

